### PR TITLE
TensorMap: Modify Erase Op to Not Return Erased Element

### DIFF
--- a/tensorflow/core/kernels/map_kernels.h
+++ b/tensorflow/core/kernels/map_kernels.h
@@ -106,23 +106,6 @@ class TensorMapSize : public OpKernel {
   }
 };
 
-class TensorMapInsert : public OpKernel {
- public:
-  explicit TensorMapInsert(OpKernelConstruction* c) : OpKernel(c) {}
-  ~TensorMapInsert() override {}
-
-  void Compute(OpKernelContext* c) override {
-    const TensorKey& key = c->input(1);
-    const Tensor& value = c->input(2);
-    const TensorMap* m = nullptr;
-    OP_REQUIRES_OK(c, GetInputMap(c, 0, &m));
-
-    TensorMap* output_map = nullptr;
-    OP_REQUIRES_OK(c, ForwardInputOrCreateNewMap(c, 0, 0, *m, &output_map));
-    output_map->replace(key, value);
-  }
-};
-
 class TensorMapLookup : public OpKernel {
  public:
   explicit TensorMapLookup(OpKernelConstruction* c) : OpKernel(c) {}
@@ -140,20 +123,37 @@ class TensorMapLookup : public OpKernel {
   }
 };
 
+class TensorMapInsert : public OpKernel {
+ public:
+  explicit TensorMapInsert(OpKernelConstruction* c) : OpKernel(c) {}
+  ~TensorMapInsert() override {}
+
+  void Compute(OpKernelContext* c) override {
+    const TensorKey& key = c->input(1);
+    const Tensor& value = c->input(2);
+    const TensorMap* m = nullptr;
+    OP_REQUIRES_OK(c, GetInputMap(c, 0, &m));
+
+    TensorMap* output_map = nullptr;
+    OP_REQUIRES_OK(c, ForwardInputOrCreateNewMap(c, 0, 0, *m, &output_map));
+    output_map->replace(key, value);
+  }
+};
+
 class TensorMapErase : public OpKernel {
  public:
   explicit TensorMapErase(OpKernelConstruction* c) : OpKernel(c) {}
 
   void Compute(OpKernelContext* c) override {
+    const TensorKey& key = c->input(1);
     const TensorMap* m = nullptr;
     OP_REQUIRES_OK(c, GetInputMap(c, 0, &m));
-    const TensorKey& key = c->input(1);
 
     OP_REQUIRES(c, m->tensors().find(key) != m->tensors().end(),
                 errors::InvalidArgument("Trying to erase non-existent item."));
 
-    const Tensor& t = m->tensors().find(key)->second;
-    c->set_output(1, t);
+    //const Tensor& t = m->tensors().find(key)->second;
+    //c->set_output(1, t);
 
     TensorMap* output_map = nullptr;
     OP_REQUIRES_OK(c, ForwardInputOrCreateNewMap(c, 0, 0, *m, &output_map));

--- a/tensorflow/core/kernels/map_kernels.h
+++ b/tensorflow/core/kernels/map_kernels.h
@@ -152,9 +152,6 @@ class TensorMapErase : public OpKernel {
     OP_REQUIRES(c, m->tensors().find(key) != m->tensors().end(),
                 errors::InvalidArgument("Trying to erase non-existent item."));
 
-    //const Tensor& t = m->tensors().find(key)->second;
-    //c->set_output(1, t);
-
     TensorMap* output_map = nullptr;
     OP_REQUIRES_OK(c, ForwardInputOrCreateNewMap(c, 0, 0, *m, &output_map));
     output_map->tensors().erase(key);

--- a/tensorflow/core/ops/map_ops.cc
+++ b/tensorflow/core/ops/map_ops.cc
@@ -33,6 +33,17 @@ REGISTER_OP("TensorMapSize")
     .Output("size: int32")
     .SetShapeFn(shape_inference::ScalarShape);
 
+REGISTER_OP("TensorMapLookup")
+    .Input("input_handle: variant")
+    .Input("key: key_dtype")
+    .Output("value: value_dtype")
+    .Attr("key_dtype: type")
+    .Attr("value_dtype: type")
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      c->set_output(0, c->UnknownShape());
+      return Status::OK();
+    });
+
 REGISTER_OP("TensorMapInsert")
     .Input("input_handle: variant")
     .Input("key: key_dtype")
@@ -45,27 +56,16 @@ REGISTER_OP("TensorMapInsert")
       return Status::OK();
     });
 
-REGISTER_OP("TensorMapLookup")
-    .Input("input_handle: variant")
-    .Input("key: key_dtype")
-    .Output("value: value_dtype")
-    .Attr("key_dtype: type")
-    .Attr("value_dtype: type")
-    .SetShapeFn([](shape_inference::InferenceContext* c) {
-      c->set_output(0, c->UnknownShape());
-      return Status::OK();
-    });
-
 REGISTER_OP("TensorMapErase")
     .Input("input_handle: variant")
     .Input("key: key_dtype")
     .Output("output_handle: variant")
-    .Output("value: value_dtype")
+    //.Output("value: value_dtype")
     .Attr("key_dtype: type")
     .Attr("value_dtype: type")
     .SetShapeFn([](shape_inference::InferenceContext* c) {
       c->set_output(0, c->Scalar());        // output map
-      c->set_output(1, c->UnknownShape());  // removed element
+      //c->set_output(1, c->UnknownShape());  // removed element
       return Status::OK();
     });
 

--- a/tensorflow/core/ops/map_ops.cc
+++ b/tensorflow/core/ops/map_ops.cc
@@ -60,12 +60,10 @@ REGISTER_OP("TensorMapErase")
     .Input("input_handle: variant")
     .Input("key: key_dtype")
     .Output("output_handle: variant")
-    //.Output("value: value_dtype")
     .Attr("key_dtype: type")
     .Attr("value_dtype: type")
     .SetShapeFn([](shape_inference::InferenceContext* c) {
       c->set_output(0, c->Scalar());        // output map
-      //c->set_output(1, c->UnknownShape());  // removed element
       return Status::OK();
     });
 

--- a/tensorflow/python/kernel_tests/map_ops_test.py
+++ b/tensorflow/python/kernel_tests/map_ops_test.py
@@ -79,19 +79,18 @@ class MapOpsTest(test_util.TensorFlowTestCase, parameterized.TestCase):
     m = map_ops.tensor_map_insert(m, k, v)
     s = map_ops.tensor_map_size(m)
     self.assertAllEqual(s, 1)
-
-    m, e = map_ops.tensor_map_erase(m, k, dtypes.float32)
+    # do the erase
+    m = map_ops.tensor_map_erase(m, k, v.dtype)
     s = map_ops.tensor_map_size(m)
     self.assertAllEqual(s, 0)
-    self.assertAllClose(e, v)
 
   def testTensorMapEraseFromEmptyMapFails(self):
     m = map_ops.empty_tensor_map()
     k = constant_op.constant(1.0)
     with self.assertRaisesRegex(errors.InvalidArgumentError,
                                 "Trying to erase non-existent item."):
-      m, e = map_ops.tensor_map_erase(m, k, dtypes.float32)
-      self.evaluate(e)
+      m = map_ops.tensor_map_erase(m, k, dtypes.float32)
+      self.evaluate(m)
 
   def testTensorMapEraseMissingKeyFails(self):
     m = map_ops.empty_tensor_map()
@@ -101,8 +100,8 @@ class MapOpsTest(test_util.TensorFlowTestCase, parameterized.TestCase):
     m = map_ops.tensor_map_insert(m, k2, v)
     with self.assertRaisesRegex(errors.InvalidArgumentError,
                                 "Trying to erase non-existent item."):
-      m, e = map_ops.tensor_map_erase(m, k, dtypes.float32)
-      self.evaluate(e)
+      m = map_ops.tensor_map_erase(m, k, dtypes.float32)
+      self.evaluate(m)
 
   def testTensorMapHasKey(self):
     m = map_ops.empty_tensor_map()
@@ -110,7 +109,7 @@ class MapOpsTest(test_util.TensorFlowTestCase, parameterized.TestCase):
     k2 = constant_op.constant(2.0)
     v = constant_op.constant(2.0)
     m = map_ops.tensor_map_insert(m, k, v)
-
+    # check has key
     b = map_ops.tensor_map_has_key(m, k)
     b2 = map_ops.tensor_map_has_key(m, k2)
     self.assertAllEqual(b, True)
@@ -186,6 +185,7 @@ class MapOpsTest(test_util.TensorFlowTestCase, parameterized.TestCase):
       self.assertAllEqual(g, 5)
 
   def testReplaceLookupGrad(self):
+    '''Same key different value'''
     with backprop.GradientTape(persistent=True) as tape:
       m = map_ops.empty_tensor_map()
       k = constant_op.constant(1.0)
@@ -198,12 +198,13 @@ class MapOpsTest(test_util.TensorFlowTestCase, parameterized.TestCase):
       self.assertAllClose(l, v)
       g = tape.gradient(l * 5, v)
       self.assertAllEqual(g, 5)
+      # replace k and lookup
       m = map_ops.tensor_map_insert(m, k, v2)
       l2 = map_ops.tensor_map_lookup(m, k, v2.dtype)
       self.assertAllClose(l2, v2)
       g2 = tape.gradient(l2 * 6, v)
-      g3 = tape.gradient(l2 * 7, v2)
       self.assertAllClose(g2, array_ops.zeros_like(v))
+      g3 = tape.gradient(l2 * 7, v2)
       self.assertAllClose(g3, 7)
     del tape
 
@@ -213,7 +214,7 @@ class MapOpsTest(test_util.TensorFlowTestCase, parameterized.TestCase):
       k = constant_op.constant(1.0)
       k2 = constant_op.constant(11.0)
       v = constant_op.constant(2.0)
-      v2 = constant_op.constant(2.0)
+      v2 = constant_op.constant(22.0)
       tape.watch(v)
       tape.watch(v2)
       m = map_ops.tensor_map_insert(m, k, v)
@@ -268,28 +269,7 @@ class MapOpsTest(test_util.TensorFlowTestCase, parameterized.TestCase):
       self.assertAllClose(g2, 2*v)
     del tape
 
-  def testEraseSecondGrad(self):
-    with backprop.GradientTape(persistent=True) as tape:
-      m = map_ops.empty_tensor_map()
-      k = constant_op.constant(1.0)
-      k2 = constant_op.constant(2.0)
-      v = constant_op.constant(11.0)
-      v2 = constant_op.constant(22.0)
-      tape.watch(v)
-      tape.watch(v2)
-      m = map_ops.tensor_map_insert(m, k, v)
-      m = map_ops.tensor_map_insert(m, k2, v2)
-      m, e = map_ops.tensor_map_erase(m, k2, v2.dtype)
-      l = map_ops.tensor_map_lookup(m, k, v.dtype)
-      self.assertAllClose(l, v)
-      self.assertAllClose(e, v2)
-      g = tape.gradient(l * 5, v)
-      self.assertAllEqual(g, 5)
-      g2 = tape.gradient(e * 6, v2)
-      self.assertAllEqual(g2, 6)
-    del tape
-
-  def testEraseFirstGrad(self):
+  def testEraseFirstInsertGrad(self):
     with backprop.GradientTape(persistent=True) as tape:
       m = map_ops.empty_tensor_map()
       k = constant_op.constant(1.0)
@@ -301,19 +281,31 @@ class MapOpsTest(test_util.TensorFlowTestCase, parameterized.TestCase):
       m = map_ops.tensor_map_insert(m, k, v)
       l = map_ops.tensor_map_lookup(m, k, v.dtype)
       m = map_ops.tensor_map_insert(m, k2, v2)
-      m, e = map_ops.tensor_map_erase(m, k, v.dtype)
+      m = map_ops.tensor_map_erase(m, k, v.dtype)
       l2 = map_ops.tensor_map_lookup(m, k2, v2.dtype)
       self.assertAllClose(l2, v2)
-      self.assertAllClose(e, v)
       g = tape.gradient(l * 5, v)
       self.assertAllEqual(g, 5)
       g2 = tape.gradient(l2 * 6, v2)
       self.assertAllEqual(g2, 6)
-      g3 = tape.gradient(e * 7, v)
-      self.assertAllEqual(g3, 7)
-      m, e2 = map_ops.tensor_map_erase(m, k2, v2.dtype)
-      g4 = tape.gradient(e2 * 8, v2)
-      self.assertAllEqual(g4, 8)
+    del tape
+
+  def testEraseSecondInsertGrad(self):
+    with backprop.GradientTape(persistent=True) as tape:
+      m = map_ops.empty_tensor_map()
+      k = constant_op.constant(1.0)
+      k2 = constant_op.constant(2.0)
+      v = constant_op.constant(11.0)
+      v2 = constant_op.constant(22.0)
+      tape.watch(v)
+      tape.watch(v2)
+      m = map_ops.tensor_map_insert(m, k, v)
+      m = map_ops.tensor_map_insert(m, k2, v2)
+      m = map_ops.tensor_map_erase(m, k2, v2.dtype)
+      l = map_ops.tensor_map_lookup(m, k, v.dtype)
+      self.assertAllClose(l, v)
+      g = tape.gradient(l * 5, v)
+      self.assertAllEqual(g, 5)
     del tape
 
   def testEraseInsertComposedGrad(self):
@@ -326,15 +318,12 @@ class MapOpsTest(test_util.TensorFlowTestCase, parameterized.TestCase):
       tape.watch(v)
       tape.watch(v2)
       m = map_ops.tensor_map_insert(m, k, v)
-      m, e = map_ops.tensor_map_erase(m, k, v.dtype)
-      m = map_ops.tensor_map_insert(m, k2, e)
-      l = map_ops.tensor_map_lookup(m, k2, e.dtype)
-      self.assertAllClose(e, v)
-      self.assertAllClose(l, e)
-      g = tape.gradient(l * 5, v)
+      l = map_ops.tensor_map_lookup(m, k, v.dtype)
+      m = map_ops.tensor_map_erase(m, k, v.dtype)
+      m = map_ops.tensor_map_insert(m, k2, l)
+      l2 = map_ops.tensor_map_lookup(m, k2, l.dtype)
+      g = tape.gradient(l2 * 5, v)
       self.assertAllEqual(g, 5)
-      g2 = tape.gradient(e * 6, v)
-      self.assertAllEqual(g2, 6)
     del tape
 
   def testStringKeyGrad(self):
@@ -344,56 +333,68 @@ class MapOpsTest(test_util.TensorFlowTestCase, parameterized.TestCase):
       k2 = constant_op.constant("key2")
       v = constant_op.constant(2.0)
       v2 = constant_op.constant(22.0)
+      tape.watch(v)
       tape.watch(v2)
-      m = map_ops.tensor_map_insert(m, k2, v2)
       m = map_ops.tensor_map_insert(m, k, v)
+      m = map_ops.tensor_map_insert(m, k2, v2)
       s = map_ops.tensor_map_size(m)
       self.assertAllEqual(s, 2)
+      # lookup and gradient
       l = map_ops.tensor_map_lookup(m, k, v.dtype)
       self.assertAllClose(l, v)
+      self.assertAllClose(tape.gradient(l * 5, v), 5)
+      # replace and gradient
       m = map_ops.tensor_map_insert(m, k, v2)
       l2 = map_ops.tensor_map_lookup(m, k, v2.dtype)
       self.assertAllClose(l2, v2)
-      g = tape.gradient(l2 * 5, v2)
-      self.assertAllEqual(g, 5)
-
-      m, e = map_ops.tensor_map_erase(m, k, v2.dtype)
+      g = tape.gradient(l2 * 6, v2)
+      self.assertAllEqual(g, 6)
+      # erase, has key, and gradient
+      m = map_ops.tensor_map_erase(m, k, v2.dtype)
       s = map_ops.tensor_map_size(m)
       self.assertAllEqual(s, 1)
-      self.assertAllClose(e, v2)
-      g2 = tape.gradient(e * 6, v2)
+      h = map_ops.tensor_map_has_key(m, k)
+      self.assertAllEqual(h, False)
+      l = map_ops.tensor_map_lookup(m, k2, v2.dtype)
+      g2 = tape.gradient(l * 6, v2)
       self.assertAllEqual(g2, 6)
     del tape
 
-  def testStringValue(self):
+  def testStringKeyValue(self):
     m = map_ops.empty_tensor_map()
     k = constant_op.constant("key")
     v = constant_op.constant("value")
     k2 = constant_op.constant(1.0)
     v2 = constant_op.constant(2.0)
+    # test insert and lookup on string key-value pair
     m = map_ops.tensor_map_insert(m, k, v)
     m = map_ops.tensor_map_insert(m, k2, v2)
     l = map_ops.tensor_map_lookup(m, k, v.dtype)
     self.assertAllEqual(l, v)
+    # test lookup on float key-value pair
     l2 = map_ops.tensor_map_lookup(m, k2, v2.dtype)
     self.assertAllClose(l2, v2)
-    m, e = map_ops.tensor_map_erase(m, k, v.dtype)
-    self.assertAllEqual(e, v)
+    # test erase and has key
+    self.assertAllEqual(map_ops.tensor_map_has_key(m, k), True)
+    m = map_ops.tensor_map_erase(m, k, v.dtype)
+    self.assertAllEqual(map_ops.tensor_map_has_key(m, k), False)
+    self.assertAllEqual(map_ops.tensor_map_has_key(m, k2), True)
 
   def testVectorValue(self):
     m = map_ops.empty_tensor_map()
     k = constant_op.constant([1.0, 2.0])
     v = constant_op.constant([11.0, 22.0])
+    # test insert and lookup
     m = map_ops.tensor_map_insert(m, k, v)
     s = map_ops.tensor_map_size(m)
     self.assertAllEqual(s, 1)
     l = map_ops.tensor_map_lookup(m, k, v.dtype)
     self.assertAllEqual(l, v)
-
-    m, e = map_ops.tensor_map_erase(m, k, v.dtype)
+    # test erase and has key
+    m = map_ops.tensor_map_erase(m, k, v.dtype)
     s = map_ops.tensor_map_size(m)
     self.assertAllEqual(s, 0)
-    self.assertAllClose(e, v)
+    self.assertAllEqual(map_ops.tensor_map_has_key(m, k), False)
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/ops/map_ops.py
+++ b/tensorflow/python/ops/map_ops.py
@@ -74,7 +74,7 @@ def InsertGrad(op, dmap):
 
 @ops.RegisterGradient("TensorMapErase")
 def EraseGrad(op, dmap):
-  m, k = op.inputs
+  _, k = op.inputs
   key_grad = None
-  map_grad = dmap #tensor_map_insert(dmap, k, v)
+  map_grad = dmap
   return map_grad, key_grad

--- a/tensorflow/python/ops/map_ops.py
+++ b/tensorflow/python/ops/map_ops.py
@@ -46,7 +46,8 @@ def tensor_map_lookup(input_handle, key, value_dtype):
 
 
 def tensor_map_erase(input_handle, key, value_dtype):
-  return gen_map_ops.tensor_map_erase(input_handle, key, value_dtype)
+  m = gen_map_ops.tensor_map_erase(input_handle, key, value_dtype)
+  return m
 
 
 def tensor_map_has_key(input_handle, key):
@@ -67,13 +68,13 @@ def InsertGrad(op, dmap):
   _, k, v = op.inputs
   key_grad = None
   (value_grad, map_grad) = control_flow_ops.cond(tensor_map_has_key(dmap, k),
-                                                 lambda: (tensor_map_lookup(dmap, k, v.dtype), tensor_map_erase(dmap, k, v.dtype)[0]),
+                                                 lambda: (tensor_map_lookup(dmap, k, v.dtype), tensor_map_erase(dmap, k, v.dtype)),
                                                  lambda: (array_ops.zeros_like(v), dmap))
   return map_grad, key_grad, value_grad
 
 @ops.RegisterGradient("TensorMapErase")
-def EraseGrad(op, dmap, dval):
-  _, k = op.inputs
+def EraseGrad(op, dmap):
+  m, k = op.inputs
   key_grad = None
-  map_grad = tensor_map_insert(dmap, k, dval)
+  map_grad = dmap #tensor_map_insert(dmap, k, v)
   return map_grad, key_grad


### PR DESCRIPTION
Modified erase op to not return erased element and modified corresponding map ops tests. @mdanatg @saxenasaurabh @dynamicwebpaige